### PR TITLE
Fix arg typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ source venv3/bin/activate
 
 python3 evaluate_referencegenome.py \
 --basecalls-path demo/model1 \
---references-path REF_GENOME.fna \
+--reference-path REF_GENOME.fna \
 --model-name model1
 
 # output -> data/model1/model1_evaluation.csv


### PR DESCRIPTION
Argument was changed in `evaluate_referencegenome.py` but not in the readme.