### PR TITLE
Improve download scripts

### DIFF
--- a/download/download_all.sh
+++ b/download/download_all.sh
@@ -4,6 +4,8 @@
 # usage:
 # bash download_all.sh OUTPUT_DIR
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
 # make the output dir if does not exists
 if [ ! -d $1 ]
 then
@@ -12,6 +14,7 @@ else
      echo "Download directory exists"
 fi
 
-source download_jain.sh "$1/jain"
-source download_verm.sh "$1/verm"
-source download_wick.sh "$1/wick"
+source "${SCRIPT_DIR}/download_jain.sh" "$1/jain"
+source "${SCRIPT_DIR}/download_verm.sh" "$1/verm"
+source "${SCRIPT_DIR}/download_wick.sh" "$1/wick"
+

--- a/download/download_jain.sh
+++ b/download/download_jain.sh
@@ -20,18 +20,18 @@ mkdir -p $genomes_dir
 while IFS= read -r line || [[ -n $line  ]]; do
     if [ ! -f "${tmp_dir}/reference.fasta.gz" ]
     then
-        echo "Downloading reference data"
+        echo "Downloading Homo sapiens reference data"
         wget $line -O "${tmp_dir}/reference.fasta.gz"
     fi
 
     if [ ! -f "${genomes_dir}/Homo_sapiens.fna" ]
     then
-        echo "Decompressing reference data"
+        echo "Decompressing Homo sapiens reference data"
         gunzip -c "${tmp_dir}/reference.fasta.gz" > "${genomes_dir}/Homo_sapiens.fna"
     fi 
 done < $references_links
 
-
+echo "Downloading Homo sapiens data"
 # download the data
 while IFS= read -r line || [[ -n $line  ]]; do
     files=($line)
@@ -40,13 +40,13 @@ while IFS= read -r line || [[ -n $line  ]]; do
     
     if [ ! -f "${tmp_dir}/${runid}_fastq.tar" ]
     then
-        echo "Downloading basecalls data"
+        echo "Downloading basecalls data for run ${runid}"
         wget ${files[1]} -O "${tmp_dir}/${runid}_fastq.tar"
     fi
 
     if [ ! -f "${tmp_dir}/${runid}_fast5.tar" ]
     then
-        echo "Downloading fast5 data"
+        echo "Downloading fast5 data for run ${runid}"
         wget ${files[0]} -O "${tmp_dir}/${runid}_fast5.tar"
     fi
 
@@ -57,15 +57,17 @@ while IFS= read -r line || [[ -n $line  ]]; do
 
     if [ -z "$(ls -A ${fastq_dir})" ]
     then
-        echo "Decompressing fastq data"
+        echo "Decompressing fastq data for run ${runid}"
         tar -xf "${tmp_dir}/${runid}_fastq.tar" -C "${run_dir}/fastq"
     fi
 
     if [ -z "$(ls -A ${fast5_dir})" ]
     then
-        echo "Decompressing fast5 data"
+        echo "Decompressing fast5 data for run ${runid}"
         tar -xf "${tmp_dir}/${runid}_fast5.tar" -C "${run_dir}/fast5"
     fi
 
 done < $data_links
+
+echo "Done"
 

--- a/download/download_jain.sh
+++ b/download/download_jain.sh
@@ -59,6 +59,8 @@ while IFS= read -r line || [[ -n $line  ]]; do
     then
         echo "Decompressing fastq data for run ${runid}"
         tar -xf "${tmp_dir}/${runid}_fastq.tar" -C "${run_dir}/fastq"
+        # Decompress (.fastq).gz in-place
+        find "${run_dir}/fastq" -name "*.gz" -exec gunzip {} \;
     fi
 
     if [ -z "$(ls -A ${fast5_dir})" ]

--- a/download/download_verm.sh
+++ b/download/download_verm.sh
@@ -20,7 +20,7 @@ mkdir -p $genomes_dir
 while IFS= read -r line || [[ -n $line  ]]; do
     if [ ! -f "${genomes_dir}/Lambda_phage.fna" ]
     then
-        echo "Downloading reference data"
+        echo "Downloading reference data for Lambda phage"
         curl -L $line > ${genomes_dir}/Lambda_phage.fna
     fi
 done < $references_links
@@ -31,10 +31,12 @@ while IFS= read -r line || [[ -n $line  ]]; do
     files=($line)
     link=${files[0]}
     spe=${files[1]}
+
+    echo "Checking status for ${spe}"
     
     if [ ! -f "${tmp_dir}/${spe}.tar" ]
     then
-        echo "Downloading data"
+        echo "Downloading all data for ${spe}"
         wget $link -O "${tmp_dir}/${spe}.tar"
     fi
 
@@ -42,12 +44,27 @@ while IFS= read -r line || [[ -n $line  ]]; do
     fastq_dir="${run_dir}/fastq"
     fast5_dir="${run_dir}/fast5"
     tmptmp_dir="${run_dir}/tmp"
-    mkdir -p $run_dir $fastq_dir $fast5_dir $tmp_dir
+    mkdir -p $run_dir $fastq_dir $fast5_dir $tmptmp_dir
 
     if [ -z "$(ls -A ${tmptmp_dir})" ]
     then
-        echo "Decompressing data"
+        echo "Decompressing data for ${spe}"
         tar -xf "${tmp_dir}/${spe}.tar" -C $tmptmp_dir
     fi
 
+    if [ -z "$(ls -A ${fast5_dir})" ]
+    then
+        echo "Moving fast5 data for ${spe}"
+        find "${tmptmp_dir}/VER5940/fast5_pass" -type f -name "*.fast5" -exec mv {} "${fast5_dir}" \;
+    fi
+
+    if [ -z "$(ls -A ${fastq_dir})" ]
+    then
+        echo "Moving fastq data for ${spe}"
+        find "${tmptmp_dir}/VER5940/fastq_pass" -type f -name "*.fastq" -exec mv {} "${fastq_dir}" \;
+    fi
+
 done < $data_links
+
+echo "Done"
+

--- a/download/download_wick.sh
+++ b/download/download_wick.sh
@@ -80,7 +80,7 @@ while IFS= read -r line || [[ -n $line  ]]; do
     fi
 
     run_dir="${output_dir}/${spe}"
-    mkdir -p ${run_dir} "${run_dir}/fast5" "${run_dir}/fastq" "${run_dir}/tmp"
+    mkdir -p ${run_dir} "${run_dir}/fast5" "${run_dir}/tmp"
 
     if [ ! -f "${run_dir}/read_references.fasta" ]
     then

--- a/download/download_wick.sh
+++ b/download/download_wick.sh
@@ -21,6 +21,7 @@ mkdir -p $tmp_dir
 genomes_dir="${output_dir}/genomes"
 mkdir -p $genomes_dir
 
+echo "Downloading general genomes"
 # download general genomes
 while IFS= read -r line || [[ -n $line  ]]; do
 
@@ -30,18 +31,18 @@ while IFS= read -r line || [[ -n $line  ]]; do
 
     if [ ! -f "${tmp_dir}/${spe}.fna.gz" ]
     then
-        echo "Downloading reference data"
+        echo "Downloading reference data for ${spe}"
         wget $link -O "${tmp_dir}/${spe}.fna.gz"
     fi
 
     if [ ! -f "${genomes_dir}/${spe}.fna" ]
     then
-        echo "Decompressing reference data"
+        echo "Decompressing reference data for ${spe}"
         gunzip -c "${tmp_dir}/${spe}.fna.gz" > "${genomes_dir}/${spe}.fna"
     fi 
 done < $references_links_general
 
-
+echo "Downloading wick specific genomes"
 # download wick specific genomes
 while IFS= read -r line || [[ -n $line  ]]; do
 
@@ -51,17 +52,18 @@ while IFS= read -r line || [[ -n $line  ]]; do
 
     if [ ! -f "${tmp_dir}/${spe}.fna.gz" ]
     then
-        echo "Downloading reference data"
+        echo "Downloading reference data for ${spe}"
         wget $link -O "${tmp_dir}/${spe}.fna.gz"
     fi
 
     if [ ! -f "${genomes_dir}/${spe}.fna" ]
     then
-        echo "Decompressing reference data"
+        echo "Decompressing reference data for ${spe}"
         gunzip -c "${tmp_dir}/${spe}.fna.gz" > "${genomes_dir}/${spe}.fna"
     fi 
 done < $references_links_specific
 
+echo "Downloading train fast5 data"
 # download train fast5 data
 while IFS= read -r line || [[ -n $line  ]]; do
 
@@ -69,27 +71,34 @@ while IFS= read -r line || [[ -n $line  ]]; do
     link=${files[0]}
     spe=${files[1]}
 
-    echo $spe
+    echo "Checking status for ${spe}"
 
     if [ ! -f "${tmp_dir}/${spe}.tar.gz" ]
     then
-        echo "Downloading fast5 data"
+        echo "Downloading fast5 data for ${spe}"
         wget $link -O "${tmp_dir}/${spe}.tar.gz"
     fi
 
     run_dir="${output_dir}/${spe}"
     mkdir -p ${run_dir} "${run_dir}/fast5" "${run_dir}/fastq" "${run_dir}/tmp"
-    tar -xvzf "${tmp_dir}/${spe}.tar.gz" -C "${run_dir}/tmp"
 
     if [ ! -f "${run_dir}/read_references.fasta" ]
     then
-        echo "Moving data"
-        find "${run_dir}/tmp" -type f -name "*.fast5" -exec mv {} "${run_dir}/fast5" \;
-        find "${run_dir}/tmp" -type f -name "read_references.fasta" -exec mv {} "${run_dir}/read_references.fasta" \;
+        echo "Extracting fast5 and reference data for ${spe}"
+        if tar -xzf "${tmp_dir}/${spe}.tar.gz" -C "${run_dir}/tmp";
+        then
+            echo "Moving fast5 data for ${spe}"
+            find "${run_dir}/tmp" -type f -name "*.fast5" -exec mv {} "${run_dir}/fast5" \;
+            find "${run_dir}/tmp" -type f -name "read_references.fasta" -exec mv {} "${run_dir}/read_references.fasta" \;
+        else
+            echo "Error extracting data for ${spe}"
+            rm -r "${run_dir}/tmp"
+        fi
     fi
 
 done < $train_fast5_links
 
+echo "Downloading test fast5 data"
 # download test fast5 data
 while IFS= read -r line || [[ -n $line  ]]; do
 
@@ -97,19 +106,23 @@ while IFS= read -r line || [[ -n $line  ]]; do
     link=${files[0]}
     spe=${files[1]}
 
+    echo "Checking status for ${spe}"
+
     if [ ! -f "${tmp_dir}/${spe}.tar.gz" ]
     then
-        echo "Downloading fast5 data"
+        echo "Downloading fast5 data for ${spe}"
         wget $link -O "${tmp_dir}/${spe}.tar.gz"
     fi
 
+    echo "Extracting data for ${spe}"
     run_dir="${output_dir}/${spe}"
     mkdir -p ${run_dir} "${run_dir}/fast5"
-    tar -xvzf "${tmp_dir}/${spe}.tar.gz" -C "${run_dir}/fast5"
+    tar -xzf "${tmp_dir}/${spe}.tar.gz" -C "${run_dir}/fast5"
     
 
 done < $test_fast5_links
 
+echo "Downloading test fastq data"
 # download test fastq data
 while IFS= read -r line || [[ -n $line  ]]; do
 
@@ -139,5 +152,5 @@ while IFS= read -r line || [[ -n $line  ]]; do
 
 done < $basecalls_links
 
-
+echo "Done"
 


### PR DESCRIPTION
I slightly changed the download scripts to be more verbose while decreasing tar verbosity (esp. in download_wick.sh). Also added support for calling download_all.sh from any location without breaking calls to the three scripts.

If you have any objections against any of these changes let me know and I'll amend.