### PR TITLE
Don't create unused tmp directory

### DIFF
--- a/evaluate_referencegenome.py
+++ b/evaluate_referencegenome.py
@@ -95,12 +95,6 @@ if __name__ == "__main__":
             fast_files.append(os.path.abspath(fast_file))
     fast_files = np.unique(fast_files)
 
-    # create a tmp dir to write tmp files
-    tmp_path = os.path.join("/".join(fast_files[0].split('/')[:-1]), 'tmp')
-    if os.path.exists(tmp_path):
-        shutil.rmtree(tmp_path)
-    os.makedirs(tmp_path)
-
     # output file name
     if args.output_file is None:
         output_file = os.path.join("/".join(fast_files[0].split('/')[:-1]), 'evaluation.csv')


### PR DESCRIPTION
In `evaluate.py`, a temporary directory is created to store the extracted read-level references, but this is not necessary when evaluating using a reference genome.